### PR TITLE
Hack together a service worker to handle offline access

### DIFF
--- a/assets/sw/pwa.js
+++ b/assets/sw/pwa.js
@@ -1,0 +1,24 @@
+self.addEventListener('install', function(event) {
+  event.waitUntil(
+    caches.open('carisenda-2018-04-11T21:32').then(function(cache) {
+      return cache
+        .addAll([
+          '/',
+          '/index.html',
+          '/static/css/all.css',
+          '/static/js/lib/moment.min.js',
+          '/static/js/datetime.js',
+          '/static/font/DINWeb-Bold.woff2',
+          '/static/font/DINWeb-Light.woff2'
+        ]);
+    })
+  );
+});
+
+self.addEventListener('fetch', function(event) {
+  event.respondWith(
+    caches.match(event.request).then(function(response) {
+      return response || fetch(event.request);
+    })
+  );
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,6 +46,12 @@ gulp.task('manifest', function() {
     .pipe(gulp.dest('build/'));
 });
 
+gulp.task('sw', function() {
+  return gulp.src('./assets/sw/**')
+    .pipe(uglify())
+    .pipe(gulp.dest('build/'));
+});
+
 gulp.task('clean', function () {
   return del(['build']);
 });
@@ -54,5 +60,5 @@ gulp.task('watch', ['build'], function() {
   gulp.watch(['src/**/*', 'assets/**/*', 'templates/**/*'], ['build']);
 });
 
-gulp.task('build', ['metalsmith', 'scripts', 'styles', 'images', 'fonts', 'manifest']);
+gulp.task('build', ['metalsmith', 'scripts', 'styles', 'images', 'fonts', 'sw', 'manifest']);
 gulp.task('default', ['build']);

--- a/templates/base.html
+++ b/templates/base.html
@@ -48,4 +48,16 @@
 
 <script src="/static/js/lib/moment.min.js"></script>
 <script src="/static/js/datetime.js"></script>
+<script>
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker
+    .register('/pwa.js', { scope: '/' })
+      .then(() => {
+        console.log("Service Worker Registered");
+      })
+      .catch((error) => {
+        console.log('Registration failed with ' + error);
+      });
+  }
+</script>
 </html>


### PR DESCRIPTION
- The maximum scope of a service worker is anything under it's location (see https://github.com/delapuente/service-workers-101/)
- The current location of js is `public/js`, all requests are above that (css, fonts, html, etc).
- Changing scope requires setting scope in `Service-Worker-Allowed` header
- `http-server` (the dev server) doesn't have options for setting headers.

Quick hack: gulp task to build sw to a higher scope.